### PR TITLE
Fixed the link for 10-605

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ expect from the core classes from the ECE and CS programs at CMU.
 ## Electives
 
 - [10-601: Introduction to Machine Learning](electives/10601.md)
-- [10-605: Machine Learning with Large Datasets](electivs/10605.md)
+- [10-605: Machine Learning with Large Datasets](electives/10605.md)
 - [11-411: Natural Language Processing](electives/11411.md)
 - [11-755/18-797: Machine Learning and Signal Processing](electives/11755.md)
 - [11-785: Introduction to Deep Learning](electives/11785.md)


### PR DESCRIPTION
# Summary of Changes

- Fixed a minor typo from electivs to electives in the link for 10605.md
